### PR TITLE
Remove all unnecessary usages of .keys(), optimize EnumField.__set__

### DIFF
--- a/binmap/__init__.py
+++ b/binmap/__init__.py
@@ -47,12 +47,13 @@ class EnumField(BaseDescriptor):
     def __set__(self, obj, value):
         if value in obj._enums[self.name]:
             obj.__dict__[f"_{self.name}"] = value
-        for k, v in obj._enums[self.name].items():
-            if v == value:
-                obj.__dict__[f"_{self.name}"] = k
-                return
+        else:
+            for k, v in obj._enums[self.name].items():
+                if v == value:
+                    obj.__dict__[f"_{self.name}"] = k
+                    return
 
-        raise ValueError("Unknown enum or value")
+            raise ValueError("Unknown enum or value")
 
 
 class ConstField(BinField):

--- a/binmap/__init__.py
+++ b/binmap/__init__.py
@@ -51,8 +51,8 @@ class EnumField(BaseDescriptor):
             if v == value:
                 obj.__dict__[f"_{self.name}"] = k
                 return
-        else:
-            raise ValueError("Unknown enum or value")
+
+        raise ValueError("Unknown enum or value")
 
 
 class ConstField(BinField):


### PR DESCRIPTION
Using x in y.keys() takes O(n) time, as we need to do a linear search through the list of keys, but doing x in y takes O(1) time, as we can check if the key exists in the dict.

Additionally, in EnumField.__set__ - if we're going to check that the item is in the obj's values and then find the appropriate key - we'll be doing 2 traversals (1 to check for the value, and another to find the corresponding key) - we can just do 1 traversal to find the corresponding key and return if it is found.

However - it may be better to reverse the order of the _enum dict to be {"South": 0}, and not {0: "South"} so that we can use a dictionary lookup, which takes O(1) time vs O(n) time, and it also makes a bit more sense (eg. python's Enum class behaves the same way).