### PR TITLE
Fix unpacking bug

### DIFF
--- a/binmap/__init__.py
+++ b/binmap/__init__.py
@@ -158,16 +158,14 @@ class Binmap(metaclass=BinmapMetaclass):
                     setattr(self, param.name, bound.arguments[param.name])
             elif param.name in self._constants:
                 self.__dict__[param.name] = self._constants[param.name]
+            elif self._datafields[param.name] in "BbHhIiLlQq":
+                setattr(self, param.name, 0)
+            elif self._datafields[param.name] in "efd":
+                setattr(self, param.name, 0.0)
+            elif self._datafields[param.name] == "c":
+                setattr(self, param.name, b"\x00")
             else:
-                val = self._datafields[param.name]
-                if val in "BbHhIiLlQq":
-                    setattr(self, param.name, 0)
-                if val in "efd":
-                    setattr(self, param.name, 0.0)
-                if val == "c":
-                    setattr(self, param.name, b"\x00")
-                else:
-                    setattr(self, param.name, b"")
+                setattr(self, param.name, b"")
 
         if len(args) == 1:
             self._binarydata = args[0]

--- a/binmap/__init__.py
+++ b/binmap/__init__.py
@@ -147,11 +147,13 @@ class Binmap(metaclass=BinmapMetaclass):
             self._formatstring += fmt
 
         bound = self.__signature__.bind(*args, **kwargs)
+
+        if "binarydata" in bound.arguments:
+            self._binarydata = bound.arguments["binarydata"]
+            self._unpacker(self._binarydata)
+
         for param in self.__signature__.parameters.values():
             if param.name in bound.arguments:
-                if param.name == "binarydata":
-                    self._binarydata = bound.arguments["binarydata"]
-                    self._unpacker(self._binarydata)
                 if param.name in self._constants:
                     raise AttributeError(f"{param.name} is a constant")
                 else:
@@ -172,7 +174,7 @@ class Binmap(metaclass=BinmapMetaclass):
             self._binarydata = args[0]
             self._unpacker(self._binarydata)
         else:
-            self._binarydata = ""
+            self._binarydata = b""
 
     def _unpacker(self, value):
         args = struct.unpack(self._formatstring, value)

--- a/binmap/__init__.py
+++ b/binmap/__init__.py
@@ -178,21 +178,15 @@ class Binmap(metaclass=BinmapMetaclass):
 
     def _unpacker(self, value):
         args = struct.unpack(self._formatstring, value)
-        print(self._formatstring)
-        print(args)
         datafields = [
             field for field in self._datafields.keys() if not field.startswith("_pad")
         ]
         for arg, name in zip(args, datafields):
-            print(arg, name)
             if name in self._constants:
-                print("Whoops!")
                 if arg != self._constants[name]:
                     raise ValueError("Constant doesn't match binary data")
             else:
-                print("Setting attr")
                 setattr(self, name, arg)
-                print(getattr(self, name))
 
     def __bytes__(self):
         """packs or unpacks all variables to a binary structure defined by

--- a/binmap/__init__.py
+++ b/binmap/__init__.py
@@ -157,7 +157,7 @@ class Binmap(metaclass=BinmapMetaclass):
                 else:
                     setattr(self, param.name, bound.arguments[param.name])
             elif param.name != "binarydata":
-                elif param.name in self._constants:
+                if param.name in self._constants:
                     self.__dict__[param.name] = self._constants[param.name]
                 elif self._datafields[param.name] in "BbHhIiLlQq":
                     setattr(self, param.name, 0)

--- a/binmap/__init__.py
+++ b/binmap/__init__.py
@@ -156,16 +156,17 @@ class Binmap(metaclass=BinmapMetaclass):
                     raise AttributeError(f"{param.name} is a constant")
                 else:
                     setattr(self, param.name, bound.arguments[param.name])
-            elif param.name in self._constants:
-                self.__dict__[param.name] = self._constants[param.name]
-            elif self._datafields[param.name] in "BbHhIiLlQq":
-                setattr(self, param.name, 0)
-            elif self._datafields[param.name] in "efd":
-                setattr(self, param.name, 0.0)
-            elif self._datafields[param.name] == "c":
-                setattr(self, param.name, b"\x00")
-            else:
-                setattr(self, param.name, b"")
+            elif param.name != "binarydata":
+                elif param.name in self._constants:
+                    self.__dict__[param.name] = self._constants[param.name]
+                elif self._datafields[param.name] in "BbHhIiLlQq":
+                    setattr(self, param.name, 0)
+                elif self._datafields[param.name] in "efd":
+                    setattr(self, param.name, 0.0)
+                elif self._datafields[param.name] == "c":
+                    setattr(self, param.name, b"\x00")
+                else:
+                    setattr(self, param.name, b"")
 
         if len(args) == 1:
             self._binarydata = args[0]

--- a/binmap/__init__.py
+++ b/binmap/__init__.py
@@ -149,21 +149,22 @@ class Binmap(metaclass=BinmapMetaclass):
         bound = self.__signature__.bind(*args, **kwargs)
         for param in self.__signature__.parameters.values():
             if param.name in bound.arguments:
-                if param.name in self._constants:
-                    raise AttributeError(f"{param.name} is a constant")
-                setattr(self, param.name, bound.arguments[param.name])
-            else:
                 if param.name == "binarydata":
-                    if param.name in bound.arguments:
-                        self._binarydata = bound.arguments[param.name]
-                        self._unpacker(bound.arguments[param.name])
+                    self._binarydata = bound.arguments[param.name]
+                    self._unpacker(bound.arguments[param.name])
                 elif param.name in self._constants:
-                    self.__dict__[param.name] = self._constants[param.name]
-                elif self._datafields[param.name] in "BbHhIiLlQq":
+                    raise AttributeError(f"{param.name} is a constant")
+                else:
+                    setattr(self, param.name, bound.arguments[param.name])
+            elif param.name in self._constants:
+                self.__dict__[param.name] = self._constants[param.name]
+            else:
+                val = self._datafields[param.name]
+                if val in "BbHhIiLlQq":
                     setattr(self, param.name, 0)
-                elif self._datafields[param.name] in "efd":
+                if val in "efd":
                     setattr(self, param.name, 0.0)
-                elif self._datafields[param.name] == "c":
+                if val == "c":
                     setattr(self, param.name, b"\x00")
                 else:
                     setattr(self, param.name, b"")


### PR DESCRIPTION
You do 
```
            if param.name in bound.arguments:
```
and then 
```
            else:	
                if param.name == "binarydata":
                    if param.name in bound.arguments:
```

If param.name is not in bound.arguments, the second check with `param.name == "binarydata"` will always fail - I moved the conditionals so that the second check would succeed.